### PR TITLE
Allow excluding whole collections and variable prefixes in ctl:ruleRemoveTargetById

### DIFF
--- a/headers/modsecurity/rule.h
+++ b/headers/modsecurity/rule.h
@@ -80,6 +80,11 @@ class Rule {
         Variables::Variables *exclusion, Variables::Variables *addition);
     inline void getFinalVars(Variables::Variables *vars,
         Variables::Variables *eclusion, Transaction *trans);
+    bool checkExcludedVariable(const std::string& key,
+                               const std::string& excluded);
+    bool checkExclusions(const std::string &key,
+                         Variables::Variables& exclusion,
+                         Transaction* trans);
     void executeActionsAfterFullMatch(Transaction *trasn,
         bool containsDisruptive, std::shared_ptr<RuleMessage> ruleMessage);
 

--- a/src/request_body_processor/json.cc
+++ b/src/request_body_processor/json.cc
@@ -142,7 +142,7 @@ int JSON::addArgument(const std::string& value) {
     }
 
 
-    m_transaction->addArgument("JSON", path + data, value, 0);
+    m_transaction->addArgument("POST", path + data, value, 0);
 
     return 1;
 }

--- a/src/rule.cc
+++ b/src/rule.cc
@@ -547,10 +547,9 @@ inline void Rule::getFinalVars(Variables::Variables *vars,
 
 bool Rule::checkExcludedVariable(const std::string& key,
                                  const std::string& excluded) {
-    bool res = false;
     // exact match
     if (key == excluded) {
-        res = true;
+        return true;
     }
     // collection match: excluded is a prefix of key, and next key char is :
     bool isCollection = excluded.find(':') == std::string::npos &&
@@ -560,7 +559,7 @@ bool Rule::checkExcludedVariable(const std::string& key,
             std::mismatch(excluded.begin(), excluded.end(), key.begin()).first
                 == excluded.end() &&
             key.at(excluded.length()) == ':') {
-        res = true;
+        return true;
     }
     // variable prefix match inside a collection if exclusion ends with .
     bool isVariablePrefix = excluded.find(':') != std::string::npos &&
@@ -569,9 +568,9 @@ bool Rule::checkExcludedVariable(const std::string& key,
             key.length() > excluded.length() &&
             std::mismatch(excluded.begin(), excluded.end(), key.begin()).first
                 == excluded.end()) {
-        res = true;
+        return true;
     }
-    return res;
+    return false;
 }
 
 bool Rule::checkExclusions(const std::string &key,

--- a/src/variables/variable.cc
+++ b/src/variables/variable.cc
@@ -77,7 +77,7 @@ void Variable::addsKeyExclusion(Variable *v) {
 
 
 std::string operator+(std::string a, Variable *v) {
-    return *v->m_fullName.get();
+    return a + *v->m_fullName.get();
 }
 
 


### PR DESCRIPTION
```
# On this API endpoint, exclude all query parameter beginning with prefix. and json args
SecRule REQUEST_URI "^/api/endpoint" "id:1,phase:1, \
  ctl:ruleRemoveTargetById=2;ARGS_GET:prefix., \
  ctl:ruleRemoveTargetById=2;ARGS_POST:json."

# Many CRS rules match ARGS
SecRule ARGS "toto" "id:2,phase:2,deny"

# Modifiy CRS rules to match separately ARGS_GET and ARGS_POST instead
SecRuleUpdateTargetById 2000 "!ARGS|ARGS_GET|ARGS_POST"
```

